### PR TITLE
Make tin-summer compatible with Rust stable

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,140 @@
+#![feature(test)]
+extern crate test;
+#[macro_use]
+extern crate clap;
+extern crate liboskar;
+
+use std::fs;
+use std::path::PathBuf;
+use test::test::Bencher;
+
+use clap::App;
+
+use liboskar::prelude::*;
+use liboskar::gitignore::*;
+
+#[bench]
+fn bench_cli_options(b: &mut Bencher) {
+    let yaml = load_yaml!("../src/cli/options-en.yml");
+    b.iter(|| {
+        App::from_yaml(yaml)
+            .version(crate_version!())
+            .get_matches_from(vec!["sn", "ar", "."])
+    })
+}
+
+#[bench]
+fn bench_to_string(b: &mut Bencher) {
+    let path = PathBuf::from("src/testdata/junk.rlib");
+    b.iter(|| path.as_path().to_str().unwrap())
+}
+
+#[bench]
+fn bench_gitignore(b: &mut Bencher) {
+    let file_contents = include_str!("../src/testdata/.gitignore");
+    b.iter(|| {
+        file_contents_to_regex(file_contents, &PathBuf::from("testdata/.gitignore"))
+    })
+}
+
+#[bench]
+fn bench_processors(b: &mut Bencher) {
+    b.iter(|| get_processors())
+}
+
+#[bench]
+fn bench_traversal_size(b: &mut Bencher) {
+    let p = PathBuf::from("src/testdata");
+    b.iter(|| read_size(&p, None, &None, false, false))
+}
+
+#[bench]
+fn bench_traversal(b: &mut Bencher) {
+    let p = PathBuf::from("src/testdata");
+    b.iter(|| read_all(&p, 4, None, None, &None, false, false))
+}
+
+#[bench]
+fn bench_traversal_sort(b: &mut Bencher) {
+    let p = PathBuf::from("src/testdata");
+    b.iter(|| {
+        let v = read_all(&p, 4, None, None, &None, false, false);
+        v.sort(None, None, false, None)
+    })
+}
+
+#[bench]
+fn bench_traversal_artifacts(b: &mut Bencher) {
+    let p = PathBuf::from("src/testdata");
+    b.iter(|| read_all(&p, 4, None, None, &None, false, true))
+}
+
+#[bench]
+fn bench_extension_regex(b: &mut Bencher) {
+    let metadata = fs::metadata("src/main.rs").unwrap();
+    b.iter(|| {
+        is_artifact(
+            "libdoggo.rlib",
+            "target/release/libdoggo.rlib",
+            &metadata,
+            false,
+            &None,
+        )
+    })
+}
+
+#[bench]
+fn get_entries(b: &mut Bencher) {
+    b.iter(|| fs::read_dir(".").unwrap())
+}
+
+#[bench]
+fn count_entries(b: &mut Bencher) {
+    b.iter(|| {
+        let paths = fs::read_dir(".").unwrap();
+        paths.count()
+    })
+}
+
+#[bench]
+fn get_entries_str(b: &mut Bencher) {
+    b.iter(|| {
+        let paths = fs::read_dir(".").unwrap();
+        for p in paths {
+            let _ = p.unwrap().path().to_str().unwrap();
+        }
+    })
+}
+
+#[bench]
+fn get_entries_metadata(b: &mut Bencher) {
+    b.iter(|| {
+        let paths = fs::read_dir(".").unwrap();
+        for p in paths {
+            let _ = p.unwrap().metadata().unwrap();
+        }
+    })
+}
+
+#[bench]
+fn get_entries_is_file(b: &mut Bencher) {
+    b.iter(|| {
+        let paths = fs::read_dir(".").unwrap();
+        for p in paths {
+            let val = p.unwrap();
+            let t = val.file_type().unwrap();
+            let _ = if t.is_file() { true } else { t.is_dir() };
+        }
+    })
+}
+
+#[bench]
+fn bench_get_metadata(b: &mut Bencher) {
+    b.iter(|| fs::metadata("src/main.rs").unwrap())
+}
+
+#[bench]
+fn bench_parser(b: &mut Bencher) {
+    let cli_input = "1M";
+    b.iter(|| threshold(Some(cli_input)))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! This is the library providing supporting functionality for the `sn` binary. The APIs here
 //! aren't stable, but you may find useful documentation of how to use `sn`.
-#![feature(test)]
-#![feature(integer_atomics)]
 #![allow(match_ref_pats)]
 #![allow(too_many_arguments)]
 #![allow(unknown_lints)]
@@ -18,6 +16,7 @@ extern crate lazy_static;
 extern crate regex;
 extern crate colored;
 
+#[cfg(test)]
 pub mod test;
 pub mod types;
 pub mod error;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,33 +1,6 @@
-#![allow(unused_imports)]
-extern crate test;
-
-use clap::App;
-use std::fs;
-use regex::{Regex, RegexSet};
 use std::path::PathBuf;
-use std::mem::replace;
-use test::test::Bencher;
 use prelude::*;
 use gitignore::*;
-use std::fs::File;
-use std::io::prelude::*;
-use colored::*;
-
-#[bench]
-fn bench_cli_options(b: &mut Bencher) {
-    let yaml = load_yaml!("cli/options-en.yml");
-    b.iter(|| {
-        App::from_yaml(yaml)
-            .version(crate_version!())
-            .get_matches_from(vec!["sn", "ar", "."])
-    })
-}
-
-#[bench]
-fn bench_to_string(b: &mut Bencher) {
-    let path = PathBuf::from("src/testdata/junk.rlib");
-    b.iter(|| path.as_path().to_str().unwrap())
-}
 
 #[test]
 fn cabal_regex_ignore() {
@@ -44,118 +17,8 @@ fn bug_regex_ignore() {
     println!("{:?}", reg);
 }
 
-#[bench]
-fn bench_gitignore(b: &mut Bencher) {
-    let file_contents = include_str!("testdata/.gitignore");
-    b.iter(|| {
-        file_contents_to_regex(file_contents, &PathBuf::from("testdata/.gitignore"))
-    })
-}
-
-#[bench]
-fn bench_processors(b: &mut Bencher) {
-    b.iter(|| get_processors())
-}
-
-#[bench]
-fn bench_traversal_size(b: &mut Bencher) {
-    let p = PathBuf::from("src/testdata");
-    b.iter(|| read_size(&p, None, &None, false, false))
-}
-
-#[bench]
-fn bench_traversal(b: &mut Bencher) {
-    let p = PathBuf::from("src/testdata");
-    b.iter(|| read_all(&p, 4, None, None, &None, false, false))
-}
-
-#[bench]
-fn bench_traversal_sort(b: &mut Bencher) {
-    let p = PathBuf::from("src/testdata");
-    b.iter(|| {
-        let v = read_all(&p, 4, None, None, &None, false, false);
-        v.sort(None, None, false, None)
-    })
-}
-
-#[bench]
-fn bench_traversal_artifacts(b: &mut Bencher) {
-    let p = PathBuf::from("src/testdata");
-    b.iter(|| read_all(&p, 4, None, None, &None, false, true))
-}
-
-#[bench]
-fn bench_extension_regex(b: &mut Bencher) {
-    let metadata = fs::metadata("src/main.rs").unwrap();
-    b.iter(|| {
-        is_artifact(
-            "libdoggo.rlib",
-            "target/release/libdoggo.rlib",
-            &metadata,
-            false,
-            &None,
-        )
-    })
-}
-
-#[bench]
-fn get_entries(b: &mut Bencher) {
-    b.iter(|| fs::read_dir(".").unwrap())
-}
-
-#[bench]
-fn count_entries(b: &mut Bencher) {
-    b.iter(|| {
-        let paths = fs::read_dir(".").unwrap();
-        paths.count()
-    })
-}
-
-#[bench]
-fn get_entries_str(b: &mut Bencher) {
-    b.iter(|| {
-        let paths = fs::read_dir(".").unwrap();
-        for p in paths {
-            let _ = p.unwrap().path().to_str().unwrap();
-        }
-    })
-}
-
-#[bench]
-fn get_entries_metadata(b: &mut Bencher) {
-    b.iter(|| {
-        let paths = fs::read_dir(".").unwrap();
-        for p in paths {
-            let _ = p.unwrap().metadata().unwrap();
-        }
-    })
-}
-
-#[bench]
-fn get_entries_is_file(b: &mut Bencher) {
-    b.iter(|| {
-        let paths = fs::read_dir(".").unwrap();
-        for p in paths {
-            let val = p.unwrap();
-            let t = val.file_type().unwrap();
-            let _ = if t.is_file() { true } else { t.is_dir() };
-        }
-    })
-}
-
-#[bench]
-fn bench_get_metadata(b: &mut Bencher) {
-    b.iter(|| fs::metadata("src/main.rs").unwrap())
-}
-
 #[test]
 fn test_parser() {
     let cli_input = "30M";
     assert_eq!(Some(30 * 1024 * 1024), threshold(Some(cli_input)));
-}
-
-#[bench]
-fn bench_parser(b: &mut Bencher) {
-    let cli_input = "1M";
-    b.iter(|| threshold(Some(cli_input)))
 }


### PR DESCRIPTION
Hi! I've done `cargo install tin-summer` earlier today, and it failed because tin-summer can't be build with stable compiler. However, it seems that we can easily support stable without losing anything? 

To do so we need to:
  - move benchmarks to `/benchmarks`, so that they are not build during
    `cargo install` (this might help with binary size as well perhaps?)
  - replace `AtomicU64` with `AtomicUsize`, which is more or less the
    same thing (there's no AtomicU64 on x86_32)!