### PR TITLE
Add `-bytes/-b` flag to display byte counts instead of human-readable values

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -49,14 +49,14 @@ fn bench_traversal_size(b: &mut Bencher) {
 #[bench]
 fn bench_traversal(b: &mut Bencher) {
     let p = PathBuf::from("src/testdata");
-    b.iter(|| read_all(&p, 4, None, None, &None, false, false))
+    b.iter(|| read_all(&p, 4, None, None, &None, false, false, false))
 }
 
 #[bench]
 fn bench_traversal_sort(b: &mut Bencher) {
     let p = PathBuf::from("src/testdata");
     b.iter(|| {
-        let v = read_all(&p, 4, None, None, &None, false, false);
+        let v = read_all(&p, 4, None, None, &None, false, false, false);
         v.sort(None, None, false, None)
     })
 }
@@ -64,7 +64,7 @@ fn bench_traversal_sort(b: &mut Bencher) {
 #[bench]
 fn bench_traversal_artifacts(b: &mut Bencher) {
     let p = PathBuf::from("src/testdata");
-    b.iter(|| read_all(&p, 4, None, None, &None, false, true))
+    b.iter(|| read_all(&p, 4, None, None, &None, false, true, false))
 }
 
 #[bench]

--- a/src/cli/options-de.yml
+++ b/src/cli/options-de.yml
@@ -8,13 +8,13 @@ subcommands:
             - dir:
                 value_name: VERZEICHNIS
                 help: Verzeichnis indem gesucht wird
-            - count: 
+            - count:
                 short: n
                 long: count
                 takes_value: true
                 value_name: ANZAHL
                 help: Anzahl an Dateien die gefunden werden sollen (Standard 20)
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
@@ -36,6 +36,10 @@ subcommands:
                 takes_value: true
                 value_name: DATEIGRÖßE
                 help: Schwellwert für Dateigröße (Standard 1MB)
+            - bytes:
+                short: b
+                long: Bytes
+                help: Bytes anzeigen
     - fat:
         about: Große Dateien/Verzeichnisse anzeigen
         args:
@@ -58,12 +62,16 @@ subcommands:
                 takes_value: true
                 value_name: PFAD
                 help: Pfade die ignoriert werden sollen
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: ANZAHL
                 help: Wie tief verschachtelt gesucht werden soll
+            - bytes:
+                short: b
+                long: Bytes
+                help: Bytes anzeigen
     - all:
         about: Alle Datein/Verzeichnis anzeigen
         args:
@@ -86,12 +94,16 @@ subcommands:
                 takes_value: true
                 value_name: PFAD
                 help: Pfade die ignoriert werden sollen
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: ANZAHL
                 help: Wie tief verschachtelt gesucht werden soll
+            - bytes:
+                short: b
+                long: Bytes
+                help: Bytes anzeigen
     - ar:
         about: Verzeichnis mit Artefakte anzeigen
         args:
@@ -128,9 +140,13 @@ subcommands:
                 takes_value: true
                 value_name: REGEX
                 help: Eigenen reguläreren Ausdruck verwenden um Artefakte zu finden. So kann z.B. `sniff ar -r .*?rlib$` verwendet werden, um `.rlib` Dateien zu finden.
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: ANZAHL
                 help: Wie tief verschachtelt gesucht werden soll
+            - bytes:
+                short: b
+                long: Bytes
+                help: Bytes anzeigen

--- a/src/cli/options-en.yml
+++ b/src/cli/options-en.yml
@@ -32,7 +32,7 @@ subcommands:
     - parallel:
         visible_alias: "p"
         alias: "par"
-        about: Same as 'all', but concurrently. 
+        about: Same as 'all', but concurrently.
         args:
             - dir:
                 value_name: DIRECTORY
@@ -53,7 +53,7 @@ subcommands:
                 takes_value: true
                 value_name: PATH
                 help: Regex for paths to exclude
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
@@ -69,6 +69,10 @@ subcommands:
                 takes_value: true
                 value_name: SIZE
                 help: Specify a threshold for file size
+            - bytes:
+                short: b
+                long: bytes
+                help: Print byte values
     - sort:
         visible_alias: "o"
         about: Find the biggest directories (optionally include files).
@@ -77,7 +81,7 @@ subcommands:
                 value_name: DIRECTORY
                 multiple: true
                 help: Directory to search
-            - count: 
+            - count:
                 short: n
                 long: count
                 takes_value: true
@@ -87,7 +91,7 @@ subcommands:
                 short: f
                 long: files
                 help: Whether to print files in addition to directories (default false)
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
@@ -111,6 +115,10 @@ subcommands:
                 takes_value: true
                 value_name: SIZE
                 help: Specify a threshold for file size
+            - bytes:
+                short: b
+                long: bytes
+                help: Print byte values
     - fat:
         visible_alias: "f"
         about: Find the biggest directories (optionally include files).
@@ -138,12 +146,16 @@ subcommands:
                 short: f
                 long: files
                 help: Whether to print files in addition to directories (default false)
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: NUMBER
                 help: How far to recurse (default 2)
+            - bytes:
+                short: b
+                long: bytes
+                help: Print byte values
     - directories:
         visible_aliases: ["d", "dir"]
         aliases: ["a", "all"]
@@ -172,12 +184,16 @@ subcommands:
                 short: f
                 long: files
                 help: Whether to print files in addition to directories (default false)
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: NUMBER
                 help: How far to recurse (default 2)
+            - bytes:
+                short: b
+                long: bytes
+                help: Print byte values
     - files:
         visible_aliases: ["l"]
         about: Show all files/directories.
@@ -201,12 +217,16 @@ subcommands:
                 short: a
                 long: all
                 help: Print all directory entries (no max depth)
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: NUMBER
                 help: How far to recurse (default 2)
+            - bytes:
+                short: b
+                long: bytes
+                help: Print byte values
     - artifacts:
         visible_aliases: ["r", "ar"]
         about: Show directories with build artifacts
@@ -233,7 +253,7 @@ subcommands:
                 short: f
                 long: files
                 help: Whether to print files in addition to directories (default false)
-            - count: 
+            - count:
                 short: n
                 long: count
                 takes_value: true
@@ -249,9 +269,13 @@ subcommands:
                 short: o
                 long: sort
                 help: Sort results by size
-            - depth: 
+            - depth:
                 short: d
                 long: depth
                 takes_value: true
                 value_name: NUMBER
                 help: How far to recurse (default 2)
+            - bytes:
+                short: b
+                long: bytes
+                help: Print byte values

--- a/src/cli/options-fr.yml
+++ b/src/cli/options-fr.yml
@@ -7,13 +7,13 @@ subcommands:
         args:
             - dir:
                 value_name: RÉPERTOIRE
-                help: Répertoire à rechercher. 
-            - count: 
+                help: Répertoire à rechercher.
+            - count:
                 short: n
                 takes_value: true
                 value_name: NUMÉRO
                 help: Numéro de fichiers à trouver.
-            - depth: 
+            - depth:
                 short: p
                 long: profondeur
                 takes_value: true
@@ -35,12 +35,16 @@ subcommands:
                 takes_value: true
                 value_name: TAILLE
                 help: Seuil de taille du fichier
+            - bytes:
+                short: o
+                long: octets
+                help: Affiche les octets
     - fat:
-        about: Afficher grands fichiers/répertoires 
+        about: Afficher grands fichiers/répertoires
         args:
             - dir:
                 value_name: RÉPERTOIRE
-                help: Répertoire à rechercher. 
+                help: Répertoire à rechercher.
             - threshold:
                 short: s
                 long: seuil
@@ -57,18 +61,22 @@ subcommands:
                 takes_value: true
                 value_name: CHEMIN
                 help: Expression régulière imposant chemins à exclure
-            - depth: 
+            - depth:
                 short: p
                 long: profondeur
                 takes_value: true
                 value_name: NUMÉRO
                 help: Profondeur à chercher (par défaut 2)
+            - bytes:
+                short: o
+                long: octets
+                help: Affiche les octets
     - all:
-        about: Affiche tout 
+        about: Affiche tout
         args:
             - dir:
                 value_name: RÉPERTOIRE
-                help: Répertoire à rechercher. 
+                help: Répertoire à rechercher.
             - threshold:
                 short: s
                 long: seuil
@@ -85,18 +93,22 @@ subcommands:
                 takes_value: true
                 value_name: CHEMIN
                 help: Expression régulière imposant chemins à exclure
-            - depth: 
+            - depth:
                 short: p
                 long: profondeur
                 takes_value: true
                 value_name: NUMÉRO
                 help: Profondeur à chercher (par défaut 2)
+            - bytes:
+                short: o
+                long: octets
+                help: Affiche les octets
     - ar:
         about: Affiche artefacts de construction
         args:
             - dir:
                 value_name: RÉPERTOIRE
-                help: Répertoire à rechercher. 
+                help: Répertoire à rechercher.
             - threshold:
                 short: s
                 long: seuil
@@ -116,7 +128,7 @@ subcommands:
             - sort:
                 short: t
                 long: trier
-                help: Trier les résultats par taille. 
+                help: Trier les résultats par taille.
             - gitignore:
                 short: g
                 long: sans-gitignore
@@ -127,9 +139,13 @@ subcommands:
                 takes_value: true
                 value_name: REGEX
                 help: Expréssion régulière pour décider si c'est un artefact. Comme exemple, pour trouver fichiers '.rlib', on pourra utiliser 'sniff ar -r .*?rlib$'.
-            - depth: 
+            - depth:
                 short: p
                 long: profondeur
                 takes_value: true
                 value_name: NUMÉRO
                 help: Profondeur à chercher (par défaut 2)
+            - bytes:
+                short: o
+                long: octets
+                help: Affiche les octets

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,9 @@ fn main() {
         // set whether to print files too
         let print_files = command.is_present("files");
 
+        // set whether to display bytes
+        let display_bytes = command.is_present("bytes");
+
         // get the number of processors to be used
         let nproc = get_threads(command.value_of("threads"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,9 @@ fn main() {
             if print_files {
                 w.with_files();
             }
+            if display_bytes {
+                w.with_bytes();
+            }
 
             if let Some(e) = regex.clone() {
                 w.set_regex(e);
@@ -152,6 +155,9 @@ fn main() {
         // don't print warnings
         //let silent = command.is_present("silent");
 
+        // set whether to display bytes
+        let display_bytes = command.is_present("bytes");
+
         // set whether to print files too
         let print_files = command.is_present("files");
 
@@ -164,15 +170,15 @@ fn main() {
         for dir in dirs {
             // get relevant filenames &c.
             let v = match regex {
-                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false),
-                _ => read_all(&dir, 0, depth, None, &None, false, false),
+                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false, display_bytes),
+                _ => read_all(&dir, 0, depth, None, &None, false, false, display_bytes),
             };
 
             // filter by depth
             let mut v_filtered = v.filtered(Some(min_bytes), !print_files, depth);
 
             // display results
-            v_filtered.display_tree(&dir);
+            v_filtered.display_tree(&dir, display_bytes);
         }
     }
     // find large files
@@ -196,6 +202,9 @@ fn main() {
         // set regex for exclusions
         let regex = command.value_of("excludes");
 
+        // set whether to display bytes
+        let display_bytes = command.is_present("bytes");
+
         // set whether to print files too
         let print_files = command.is_present("files");
 
@@ -205,15 +214,15 @@ fn main() {
         for dir in dirs {
             // get relevant filenames &c.
             let v = match regex {
-                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false),
-                _ => read_all_fast(&dir, 0, depth),
+                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false, display_bytes),
+                _ => read_all_fast(&dir, 0, depth, display_bytes),
             };
 
             // filter by depth
             let mut v_filtered = v.filtered(min_bytes, !print_files, depth);
 
             // display results
-            v_filtered.display_tree(&dir);
+            v_filtered.display_tree(&dir, display_bytes);
         }
     } else if let Some(command) = matches.subcommand_matches("files") {
         // set threshold
@@ -235,6 +244,9 @@ fn main() {
         // set regex for exclusions
         let regex = command.value_of("excludes");
 
+        // set whether to display bytes
+        let display_bytes = command.is_present("bytes");
+
         // set whether to print files too
         let print_files = true;
 
@@ -244,15 +256,15 @@ fn main() {
         for dir in dirs {
             // get relevant filenames &c.
             let v = match regex {
-                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false),
-                _ => read_all(&dir, 0, depth, None, &None, false, false),
+                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false, display_bytes),
+                _ => read_all(&dir, 0, depth, None, &None, false, false, display_bytes),
             };
 
             // filter by depth
             let mut v_filtered = v.filtered(min_bytes, !print_files, depth);
 
             // display results
-            v_filtered.display_tree(&dir);
+            v_filtered.display_tree(&dir, display_bytes);
         }
     } else if let Some(command) = matches.subcommand_matches("artifacts") {
         // set threshold
@@ -284,6 +296,9 @@ fn main() {
         // decide whether to sort
         let should_sort = command.is_present("sort");
 
+        // set whether to display bytes
+        let display_bytes = command.is_present("bytes");
+
         // set whether to print files too
         let print_files = command.is_present("files");
 
@@ -293,7 +308,7 @@ fn main() {
         for dir in dirs {
             // get relevant filenames &c.
             let excludes = get_excludes(command.value_of("excludes"));
-            let v = read_all(&dir, 0, depth, Some(&excludes), &None, vimtags, true);
+            let v = read_all(&dir, 0, depth, Some(&excludes), &None, vimtags, true, display_bytes);
 
             let mut v_processed = if should_sort {
                 v.sort(num_int, min_bytes, !print_files, depth)
@@ -301,7 +316,7 @@ fn main() {
                 v.filtered(min_bytes, !print_files, depth)
             };
 
-            v_processed.display_tree(&dir);
+            v_processed.display_tree(&dir, display_bytes);
         }
     }
     // sort entities by size
@@ -332,6 +347,9 @@ fn main() {
         // set whether to print files too
         let print_files = command.is_present("files");
 
+        // set whether to display bytes
+        let display_bytes = command.is_present("bytes");
+
         // set path to dirs
         let dirs = get_dirs(command.values_of("dir"));
 
@@ -345,15 +363,15 @@ fn main() {
 
             // get relevant filenames &c.
             let v = match regex {
-                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false),
-                _ => read_all(&dir, 0, depth, None, &None, false, false),
+                Some(r) => read_all(&dir, 0, depth, Some(&check_regex(r)), &None, false, false, display_bytes),
+                _ => read_all(&dir, 0, depth, None, &None, false, false, display_bytes),
             };
 
             // sort them
             let mut v_sorted = v.sort(num_int, min_bytes, !print_files, depth);
 
             // display sorted filenames
-            v_sorted.display_tree(&dir);
+            v_sorted.display_tree(&dir, display_bytes);
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,7 +55,7 @@ pub struct FileTree {
     files: Vec<NamePair>,
 }
 
-pub fn display_item(name: &str, bytes: FileSize) {
+pub fn display_item<T: fmt::Display>(name: &T, bytes: FileSize) {
     if bytes != FileSize::new(0) {
         let to_formatted = format!("{}", bytes);
         println!("{}\t {}", &to_formatted.green(), name);
@@ -179,17 +179,10 @@ impl FileTree {
         // display stuff
         let vec = &self.files;
         for name_pair in vec {
-            if name_pair.bytes != FileSize::new(0) {
-                let to_formatted = format!("{}", name_pair.bytes);
-                println!("{}\t {}", &to_formatted.green(), name_pair.name);
-            }
+            display_item(&name_pair.name, name_pair.bytes);
         }
 
-        if self.file_size != FileSize::new(0) {
-            let to_formatted = format!("{}", self.file_size);
-            let path = init_dir.display();
-            println!("{}\t {}", &to_formatted.green(), path);
-        }
+        display_item(&init_dir.display(), self.file_size);
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,9 +55,10 @@ pub struct FileTree {
     files: Vec<NamePair>,
 }
 
-pub fn display_item<T: fmt::Display>(name: &T, bytes: FileSize) {
+pub fn display_item<T: fmt::Display>(name: &T, bytes: FileSize, display_bytes: bool) {
     if bytes != FileSize::new(0) {
-        let to_formatted = format!("{}", bytes);
+        let to_formatted = if display_bytes { format!("{:?}", bytes) }
+                           else { format!("{}", bytes) };
         println!("{}\t {}", &to_formatted.green(), name);
     }
 }
@@ -175,14 +176,14 @@ impl FileTree {
         self.files.push(NamePair::new(path, size, depth, is_dir));
     }
 
-    pub fn display_tree(&mut self, init_dir: &PathBuf) -> () {
+    pub fn display_tree(&mut self, init_dir: &PathBuf, with_bytes: bool) -> () {
         // display stuff
         let vec = &self.files;
         for name_pair in vec {
-            display_item(&name_pair.name, name_pair.bytes);
+            display_item(&name_pair.name, name_pair.bytes, with_bytes);
         }
 
-        display_item(&init_dir.display(), self.file_size);
+        display_item(&init_dir.display(), self.file_size, with_bytes);
     }
 }
 

--- a/src/walk_parallel/mod.rs
+++ b/src/walk_parallel/mod.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 use std::process::exit;
 use std::sync::atomic::AtomicUsize;
 use std::thread;
-use types::FileSize;
+use types::{FileSize, display_item};
 use utils::size;
 
 pub use walk_parallel::single_threaded::*;
@@ -264,8 +264,7 @@ impl Walk {
 
             if let Ok(l) = in_paths.metadata() {
                 let size = size(&l, w.get_blocks); // l.len();
-                let to_formatted = format!("{}", FileSize::new(size));
-                println!("{}\t {}", &to_formatted.green(), in_paths.display());
+                display_item(&in_paths.display(), FileSize::new(size));
             } else {
                 panic!("{}", Internal::IoError);
             }
@@ -434,8 +433,5 @@ pub fn print_parallel(w: Walk) -> () {
     let size = FileSize::new(m as u64);
 
     // print directory total.
-    if size != FileSize::new(0) {
-        let to_formatted = format!("{}", size);
-        println!("{}\t {}", &to_formatted.green(), path_display.display());
-    }
+    display_item(&path_display.display(), size);
 }

--- a/src/walk_parallel/single_threaded.rs
+++ b/src/walk_parallel/single_threaded.rs
@@ -316,6 +316,7 @@ pub fn read_all(
     maybe_gitignore: &Option<RegexSet>,
     vimtags: bool,
     artifacts_only: bool,
+    display_bytes: bool,
 ) -> FileTree {
     // attempt to read the .gitignore
     let mut tree = FileTree::new();
@@ -399,6 +400,7 @@ pub fn read_all(
                                 &gitignore,
                                 vimtags,
                                 artifacts_only,
+                                display_bytes,
                             );
                             let dir_size = subtree.file_size;
                             tree.push(
@@ -423,6 +425,7 @@ pub fn read_all(
                             &gitignore,
                             vimtags,
                             artifacts_only,
+                            display_bytes,
                         );
                         let dir_size = subtree.file_size;
                         tree.push(
@@ -465,7 +468,7 @@ pub fn read_all(
 
         if let Ok(l) = in_paths.metadata() {
             let size = l.len();
-            display_item(&in_paths.display(), FileSize::new(size));
+            display_item(&in_paths.display(), FileSize::new(size), display_bytes);
         } else {
             panic!("{}", Internal::IoError);
         }
@@ -555,7 +558,7 @@ pub fn read_no_excludes(
 }
 
 /// Function to process directory contents and return a `FileTree` struct.
-pub fn read_all_fast(in_paths: &PathBuf, depth: u8, max_depth: Option<u8>) -> FileTree {
+pub fn read_all_fast(in_paths: &PathBuf, depth: u8, max_depth: Option<u8>, display_bytes: bool) -> FileTree {
     // attempt to read the .gitignore
     let mut tree = FileTree::new();
 
@@ -626,7 +629,7 @@ pub fn read_all_fast(in_paths: &PathBuf, depth: u8, max_depth: Option<u8>) -> Fi
                             );
                             ""
                         };
-                        let mut subtree = read_all_fast(&path, depth + 1, max_depth);
+                        let mut subtree = read_all_fast(&path, depth + 1, max_depth, display_bytes);
                         let dir_size = subtree.file_size;
                         tree.push(
                             path_string.to_string(),
@@ -648,7 +651,7 @@ pub fn read_all_fast(in_paths: &PathBuf, depth: u8, max_depth: Option<u8>) -> Fi
                         );
                         ""
                     };
-                    let mut subtree = read_all_fast(&path, depth + 1, max_depth);
+                    let mut subtree = read_all_fast(&path, depth + 1, max_depth, display_bytes);
                     let dir_size = subtree.file_size;
                     tree.push(
                         path_string.to_string(),
@@ -674,7 +677,7 @@ pub fn read_all_fast(in_paths: &PathBuf, depth: u8, max_depth: Option<u8>) -> Fi
     else if !in_paths.is_dir() {
         if let Ok(l) = in_paths.metadata() {
             let size = l.len();
-            display_item(&in_paths.display(), FileSize::new(size));
+            display_item(&in_paths.display(), FileSize::new(size), display_bytes);
         } else {
             panic!("{}", Internal::IoError);
         }

--- a/src/walk_parallel/single_threaded.rs
+++ b/src/walk_parallel/single_threaded.rs
@@ -465,8 +465,7 @@ pub fn read_all(
 
         if let Ok(l) = in_paths.metadata() {
             let size = l.len();
-            let to_formatted = format!("{}", FileSize::new(size));
-            println!("{}\t {}", &to_formatted.green(), in_paths.display());
+            display_item(&in_paths.display(), FileSize::new(size));
         } else {
             panic!("{}", Internal::IoError);
         }
@@ -675,8 +674,7 @@ pub fn read_all_fast(in_paths: &PathBuf, depth: u8, max_depth: Option<u8>) -> Fi
     else if !in_paths.is_dir() {
         if let Ok(l) = in_paths.metadata() {
             let size = l.len();
-            let to_formatted = format!("{}", FileSize::new(size));
-            println!("{}\t {}", &to_formatted.green(), in_paths.display());
+            display_item(&in_paths.display(), FileSize::new(size));
         } else {
             panic!("{}", Internal::IoError);
         }


### PR DESCRIPTION
This PR addresses #6, though very inelegantly. 

- Creates a new flag `--bytes` that displays byte values instead of human-readable values for all output. (I put Google Translate-based guesses in for French and German translations, as I don't speak those languages.)
- Modifies the (unused) `display_item` function to work with any `T` implementing `Display` and take a `display_bytes` flag, and updates all code locations where file or directory sizes are printed so that this function is used. (This introduces a check that `size != FileSize::new(0)` in all print statements, which does not match prior behavior e.g. at diff-9801ad6b6d07be3a4b68f9fd9e3b9832R273 or at diff-5899cfb17ab780a6ee6255135e9f06feR680. This would be easy to rectify if there is a concern.)
- Modifies the `read_all`, `read_all_fast`, `display_tree` fns, and the `Walk` struct, to add parameters or fields capturing whether or not data should be displayed as bytes.
- Modifies relevant invocations of all these functions to take the correct parameter for displaying the bytes value.

Please let me know what I can change in this PR to make it usable - this is my first time attempting to contribute to this project.