### PR TITLE
Fix deb metadata placement in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/vmchale/tin-summer"
 version = "1.21.8"
 
-[metadata.deb]
+[package.metadata.deb]
 extended-description = "Command-line tool written as a partial replacement for du. Automitically sniffs our build artifacts and can optionally clean them as well."
 license-file = ["LICENSE"]
 


### PR DESCRIPTION
Custom metadata is placed in `[package.metadata]`, not `[metadata]`, as shown in https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table-optional and https://github.com/mmstick/cargo-deb#packagemetadatadeb-options.