### PR TITLE
Restore compatibility with stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
 
 matrix:
   include:
+    # Minimum stable Rust
+    - env: TARGET=x86_64-unknown-linux-gnu  # FEATURES="simd pattern"
+      rust: 1.26.2
+
     # Linux
     - env: TARGET=x86_64-unknown-linux-gnu  # FEATURES="simd pattern"
       rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 //! This is the library providing supporting functionality for the `sn` binary. The APIs here
 //! aren't stable, but you may find useful documentation of how to use `sn`.
-#![allow(clippy::too_many_arguments)]
+
 #![allow(unknown_lints)]
-#![allow(clippy::unreadable_literal)]
+#![cfg_attr(feature = "cargo-clippy", allow(
+    renamed_and_removed_lints,
+    too_many_arguments,
+    unreadable_literal,
+))]
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+#![cfg_attr(feature = "cargo-clippy", allow(
+    renamed_and_removed_lints,
+    cyclomatic_complexity,
+    unreadable_literal,
+))]
+
 #[macro_use]
 extern crate clap;
 
@@ -11,9 +17,6 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-#[allow(unknown_lints)]
-#[allow(clippy::cyclomatic_complexity)]
-#[allow(clippy::unreadable_literal)]
 fn main() {
     // command-line parser
     #[cfg(feature = "english")]


### PR DESCRIPTION
Also set the minimum required Rust to 1.26 and track that version in CI to prevent accidental breakages.