### PR TITLE
Fix "windows" compatibility + logic bug

### DIFF
--- a/src/walk_parallel/single_threaded.rs
+++ b/src/walk_parallel/single_threaded.rs
@@ -195,7 +195,7 @@ pub fn is_artifact(
         if REGEX.is_match(path_str) || (path_str == "tags" && vimtags) {
             true
         } else if let Some(ref x) = *gitignore {
-            if is_executable(path_str, metadata) || REGEX_GITIGNORE.is_match(path_str) {
+            if is_executable(path_str, metadata) && REGEX_GITIGNORE.is_match(path_str) {
                 x.is_match(full_path)
             } else {
                 false


### PR DESCRIPTION
1. fixes "windows" compatibility
2. changes is_artifact() logic to correspond to the documentation
  - the function docs specify "executable *AND* within '.gitignore'", but the logic used OR
  - as a separate commit if not desired; alternatively the function docs can be corrected