### PR TITLE
fix windows color (adding color for later Win10 versions)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ num_cpus = "1.8.0"
 pad = "0.1.4"
 walkdir = "2.1.3"
 regex = "1.0"
+ansi_term = "0.11.0"
 
 [dependencies.clap]
 features = ["yaml"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate clap;
 
+#[cfg(target = "windows")]
+extern crate ansi_term;
+
 extern crate colored;
 extern crate liboskar;
 
@@ -27,6 +30,15 @@ fn main() {
         .set_term_width(90)
         .setting(AppSettings::SubcommandRequired)
         .get_matches();
+
+    #[cfg(not(target = "windows"))]
+    let color_ok = true;
+    #[cfg(target = "windows")]
+    let color_ok = !ansi_term::enable_ansi_support().is_ok();
+
+    if !color_ok {
+        colored::control::set_override(false);
+    }
 
     // TODO this should install manpages?
     if let Some(x) = matches.subcommand_matches("update") {


### PR DESCRIPTION
.# Discussion

This fixes Windows color support, turning it off when not supported, and enabling Win10 display of color when possible. The code enabling support will likely work, but may be subject to change or improvement when [colored/PR#47](https://github.com/mackwic/colored/pull/47) is merged.