### PR TITLE
Add ZSH completions and fix build notice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ deutsch = []
 english = []
 fish = []
 francais = []
+zsh = []
 
 [lib]
 name = "liboskar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/vmchale/tin-summer"
 version = "1.21.13"
 
 [metadata.deb]
-extended-description = "Command-line tool written as a partial replacement for du. Automitically sniffs our build artifacts and can optionally clean them as well."
+extended-description = "Command-line tool written as a partial replacement for du. Automatically sniffs our build artifacts and can optionally clean them as well."
 license-file = ["LICENSE"]
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -33,13 +33,7 @@ page](https://github.com/vmchale/tin-summer/releases).
 If your platform doesn't have binaries, or you just want to build from source, get [cargo](https://rustup.rs/). Then:
 
 ```bash
- $ cargo install tin-summer
-```
-
-Make sure you are on nightly; otherwise
-
-```bash
- $ rustup run nightly cargo install tin-summer
+$ cargo install tin-summer
 ```
 
 ## Use

--- a/build.rs
+++ b/build.rs
@@ -24,14 +24,25 @@ fn main() {
     let yaml = load_yaml!("src/cli/options-fr.yml");
     #[cfg(feature = "deutsch")]
     let yaml = load_yaml!("src/cli/options-de.yml");
-    let mut app = App::from_yaml(yaml).version(crate_version!());
 
     // generate bash completions if desired
     #[cfg(feature = "bash")]
-    app.gen_completions("sn", Shell::Bash, env!("BASH_COMPLETIONS_DIR"));
+    {
+        let mut app = App::from_yaml(yaml).version(crate_version!());
+        app.gen_completions("sn", Shell::Bash, env!("BASH_COMPLETIONS_DIR"));
+    }
 
     // generate fish completions if desired
-    let mut app_snd = App::from_yaml(yaml).version(crate_version!());
     #[cfg(feature = "fish")]
-    app_snd.gen_completions("sn", Shell::Fish, env!("FISH_COMPLETIONS_DIR"));
+    {
+        let mut app = App::from_yaml(yaml).version(crate_version!());
+        app.gen_completions("sn", Shell::Fish, env!("FISH_COMPLETIONS_DIR"));
+    }
+
+    // generate fish completions if desired
+    #[cfg(feature = "zsh")]
+    {
+        let mut app = App::from_yaml(yaml).version(crate_version!());
+        app.gen_completions("sn", Shell::Zsh, env!("ZSH_COMPLETIONS_DIR"));
+    }
 }


### PR DESCRIPTION
While updating the Arch Linux packaging for this I noticed that Rust nightly is _not_ required as advertised (I'm sure it was at some point, but maybe for features that are now in the stable release?). That makes it much easier to build packages!

This fixes the notice about Rust versions and adds an option to build ZSH shell completions (more commonly used than Fish!).