### PR TITLE
Fixed issue #37: No `mode()` method for `Permitions`

### DIFF
--- a/src/walk_parallel/single_threaded.rs
+++ b/src/walk_parallel/single_threaded.rs
@@ -189,7 +189,7 @@ pub fn is_artifact(
         if REGEX.is_match(path_str) || (path_str == "tags" && vimtags) {
             true
         } else if let Some(ref x) = *gitignore {
-            if metadata.permissions().mode() == 0o755 || REGEX_GITIGNORE.is_match(path_str) {
+            if !metadata.permissions().readonly() || REGEX_GITIGNORE.is_match(path_str) {
                 x.is_match(full_path)
             } else {
                 false


### PR DESCRIPTION
Fixed issue #37 

`metadata.permissions()` does not contain a `mode()` method, only a `.readonly()` method. It does have a trait `PermitionExt` but it is only supported for `Unix` systems. 

tin-summer now builds and runs on Windows and test passed.