### PR TITLE
Permission `mode` for windows *alongside* the Unix implementation

### DIFF
--- a/src/walk_parallel/single_threaded.rs
+++ b/src/walk_parallel/single_threaded.rs
@@ -15,6 +15,16 @@ use utils::*;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::PermissionsExt;
 
+#[cfg(not(target_os = "windows"))]
+fn is_readable(metadata: &Metadata) -> bool {
+    metadata.permissions().mode() == 0o755
+}
+
+#[cfg(target_os = "windows")]
+fn is_readable(metadata: &Metadata) -> bool {
+    metadata.permissions().readonly()
+}
+
 pub fn glob_exists(s: &str) -> bool {
     glob(s).unwrap().filter_map(Result::ok).count() != 0 // ok because panic on IO Errors shouldn't happen.
 }
@@ -189,7 +199,7 @@ pub fn is_artifact(
         if REGEX.is_match(path_str) || (path_str == "tags" && vimtags) {
             true
         } else if let Some(ref x) = *gitignore {
-            if metadata.permissions().mode() == 0o755 || REGEX_GITIGNORE.is_match(path_str) {
+            if is_readable(metadata) || REGEX_GITIGNORE.is_match(path_str) {
                 x.is_match(full_path)
             } else {
                 false


### PR DESCRIPTION
Fixed #40 and #37 by implementing a -somewhat- cross platform solution.

This issues were addressed before, in #38 but it is imaginably not precise in Unix.
(Since 755 permission mode is not *quite* the `readonly`, but windows users just don't have much of a choice)

So I made a **OS dependent** function to check a file metadata permission: `is_readable`. 
- **In Unix:** This function will be checking the `755 mode` (aka the previous method)
- **In Windows:** It will return whether the directory is `readonly` or not
